### PR TITLE
Handle tables with no headers by creating an empty Markdown header

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -35,13 +35,21 @@ rules.table = {
   // Only convert tables with a heading row.
   // Tables with no heading row are kept using `keep` (see below).
   filter: function (node) {
-    return node.nodeName === 'TABLE' && isHeadingRow(node.rows[0])
+    return node.nodeName === 'TABLE'
   },
 
-  replacement: function (content) {
+  replacement: function (content, node) {
+    // If table has no heading, add an empty one so as to get a valid Markdown table
+    var firstRow = node.rows.length ? node.rows[0] : null
+    var columnCount = firstRow ? firstRow.childNodes.length : 0
+    var emptyHeader = ''
+    if (columnCount && !isHeadingRow(firstRow)) {
+      emptyHeader = '|' + '     |'.repeat(columnCount) + '\n' + '|' + ' --- |'.repeat(columnCount)
+    }
+    
     // Ensure there are no blank lines
     content = content.replace('\n\n', '\n')
-    return '\n\n' + content + '\n\n'
+    return '\n\n' + emptyHeader + content + '\n\n'
   }
 }
 
@@ -91,7 +99,7 @@ function cell (content, node) {
 
 export default function tables (turndownService) {
   turndownService.keep(function (node) {
-    return node.nodeName === 'TABLE' && !isHeadingRow(node.rows[0])
+    return node.nodeName === 'TABLE'
   })
   for (var key in rules) turndownService.addRule(key, rules[key])
 }

--- a/src/tables.js
+++ b/src/tables.js
@@ -46,7 +46,7 @@ rules.table = {
     if (columnCount && !isHeadingRow(firstRow)) {
       emptyHeader = '|' + '     |'.repeat(columnCount) + '\n' + '|' + ' --- |'.repeat(columnCount)
     }
-    
+
     // Ensure there are no blank lines
     content = content.replace('\n\n', '\n')
     return '\n\n' + emptyHeader + content + '\n\n'

--- a/test/index.html
+++ b/test/index.html
@@ -262,17 +262,20 @@
 | --- |</pre>
 </div>
 
-<div class="case" data-name="non-definitive heading row (not converted)">
+<div class="case" data-name="non-definitive heading row (converted but with empty header)">
   <div class="input">
     <table>
       <tr><td>Row 1 Cell 1</td><td>Row 1 Cell 2</td></tr>
       <tr><td>Row 2 Cell 1</td><td>Row 2 Cell 2</td></tr>
     </table>
   </div>
-  <pre class="expected">&lt;table&gt;&lt;tbody&gt;&lt;tr&gt;&lt;td&gt;Row 1 Cell 1&lt;/td&gt;&lt;td&gt;Row 1 Cell 2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Row 2 Cell 1&lt;/td&gt;&lt;td&gt;Row 2 Cell 2&lt;/td&gt;&lt;/tr&gt;&lt;/tbody&gt;&lt;/table&gt;</pre>
+  <pre class="expected">|     |     |
+| --- | --- |
+| Row 1 Cell 1 | Row 1 Cell 2 |
+| Row 2 Cell 1 | Row 2 Cell 2 |</pre>
 </div>
 
-<div class="case" data-name="non-definitive heading row with th (not converted)">
+<div class="case" data-name="non-definitive heading row with th (converted but with empty header)">
   <div class="input">
     <table>
       <tr>
@@ -285,7 +288,10 @@
       </tr>
     </table>
   </div>
-  <pre class="expected">&lt;table&gt;&lt;tbody&gt;&lt;tr&gt;&lt;th&gt;Heading&lt;/th&gt;&lt;td&gt;Not a heading&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Heading&lt;/td&gt;&lt;td&gt;Not a heading&lt;/td&gt;&lt;/tr&gt;&lt;/tbody&gt;&lt;/table&gt;</pre>
+  <pre class="expected">|     |     |
+| --- | --- |
+| Heading | Not a heading |
+| Heading | Not a heading |</pre>
 </div>
 
 <div class="case" data-name="highlighted code block with html">


### PR DESCRIPTION
The current behaviour of the table plugin is to return the full HTML if the table has no header. However this is an issue if the user wants actual Markdown regardless of the table layout, especially when the original HTML has many classes or attributes, which makes the text unreadable.

In this pull request, if a table with no header is detected, an empty header is added instead, so it would turn something like this:

```
<table>
      <tr><td>Row 1 Cell 1</td><td>Row 1 Cell 2</td></tr>
      <tr><td>Row 2 Cell 1</td><td>Row 2 Cell 2</td></tr>
</table>
```

Into this:

```
|     |     |
| --- | --- |
| Row 1 Cell 1 | Row 1 Cell 2 |
| Row 2 Cell 1 | Row 2 Cell 2 |
```

Which will render "correctly" to:

|     |     |
| --- | --- |
| Row 1 Cell 1 | Row 1 Cell 2 |
| Row 2 Cell 1 | Row 2 Cell 2 |

Although the empty header is not ideal it still is valid Markdown.