### PR TITLE
Two tildes for strikethrough (as per specs)

### DIFF
--- a/src/strikethrough.js
+++ b/src/strikethrough.js
@@ -2,7 +2,7 @@ export default function strikethrough (turndownService) {
   turndownService.addRule('strikethrough', {
     filter: ['del', 's', 'strike'],
     replacement: function (content) {
-      return '~' + content + '~'
+      return '~~' + content + '~~'
     }
   })
 }

--- a/test/index.html
+++ b/test/index.html
@@ -11,17 +11,17 @@
 
 <div class="case" data-name="strike">
   <div class="input"><strike>Lorem ipsum</strike></div>
-  <pre class="expected">~Lorem ipsum~</pre>
+  <pre class="expected">~~Lorem ipsum~~</pre>
 </div>
 
 <div class="case" data-name="s">
   <div class="input"><s>Lorem ipsum</s></div>
-  <pre class="expected">~Lorem ipsum~</pre>
+  <pre class="expected">~~Lorem ipsum~~</pre>
 </div>
 
 <div class="case" data-name="del">
   <div class="input"><del>Lorem ipsum</del></div>
-  <pre class="expected">~Lorem ipsum~</pre>
+  <pre class="expected">~~Lorem ipsum~~</pre>
 </div>
 
 <div class="case" data-name="unchecked inputs">


### PR DESCRIPTION
Follow GFM specs for strikethrough

>Strikethrough text is any text wrapped in **two** tildes (~).

Source: https://github.github.com/gfm/#strikethrough-extension-

The wording might be confusing, but it's actually two tildes on each side, as seen in the example given:

`~~Hi~~ Hello, world!`

Having only one tilde on each side breaks markdown on things that follow the spec more strictly.

Fixes #12 