### PR TITLE
fix: hardening against reference error in tables.js

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -59,6 +59,7 @@ rules.tableSection = {
 // - and every cell is a TH
 function isHeadingRow (tr) {
   var parentNode = tr.parentNode
+  if (!parentNode) return false
   return (
     parentNode.nodeName === 'THEAD' ||
     (


### PR DESCRIPTION
* we just return `false` early if there is no `parentNode`.